### PR TITLE
Fixed deprecation warnings in Gradle 9.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,8 +77,8 @@ gradlePlugin {
 }
 
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    val signingKey = project.findProperty("signingKey") as String?
+    val signingPassword = project.findProperty("signingPassword") as String?
     useInMemoryPgpKeys(signingKey, signingPassword)
 }
 

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/dsl/DependencyConstraintFactoriesImpl.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/dsl/DependencyConstraintFactoriesImpl.kt
@@ -1,6 +1,7 @@
 package io.github.sgtsilvio.gradle.oci.internal.dsl
 
 import io.github.sgtsilvio.gradle.oci.dsl.DependencyConstraintFactories
+import io.github.sgtsilvio.gradle.oci.internal.gradle.createDependency
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
@@ -17,7 +18,8 @@ abstract class DependencyConstraintFactoriesImpl(
     final override fun constraint(dependencyConstraintNotation: CharSequence): DependencyConstraint =
         dependencyConstraintHandler.create(dependencyConstraintNotation)
 
-    final override fun constraint(project: Project): DependencyConstraint = dependencyConstraintHandler.create(project)
+    final override fun constraint(project: Project): DependencyConstraint =
+        dependencyConstraintHandler.create(project.createDependency())
 
     private fun constraint(dependency: MinimalExternalModuleDependency): DependencyConstraint =
         dependencyConstraintHandler.create(dependency)

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/gradle/DependencyExtensions.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/gradle/DependencyExtensions.kt
@@ -5,7 +5,7 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.attributes.Attribute
 
-internal fun Project.createDependency() = project.dependencies.create(project) as ProjectDependency
+internal fun Project.createDependency(): ProjectDependency = dependencyFactory.createProjectDependency(path)
 
 internal fun <T : ModuleDependency, A : Any> T.attribute(key: Attribute<A>, value: A): T {
     attributes {


### PR DESCRIPTION
Gradle 9.6.0 is out and marked a bunch of methods as deprecated (see [Upgrade guide](https://docs.gradle.org/9.6.0/userguide/upgrading_version_9.html#changes_9.6.0))