### PR TITLE
feat: resolve registry qualified coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,39 @@ This section of the documentation is still WIP.
 
 - split registry from image name (same as Gradle's repositories and dependencies)
 
+#### Registry Qualified Coordinates
+
+Splitting the registry from the image name reaches its limit when an image is consumed that was built by another build.
+Parent images are transitive dependencies, and repositories are not part of a published component, so the consuming
+build resolves the parent images against its own repositories although only the build that defines the image knows
+their registry.
+
+A coordinate can therefore name its registry, separated from the image namespace by `!`:
+
+```kotlin
+oci {
+    registries {
+        dockerHub {
+            optionalCredentials()
+        }
+    }
+    imageDefinitions.register("main") {
+        allPlatforms {
+            dependencies {
+                runtime("public.ecr.aws!hivemq.base-images:eclipse-temurin:sha256!5e349bf2...")
+            }
+        }
+    }
+}
+```
+
+Such a coordinate is resolved without declaring its registry, keeps its whole namespace, so no image mapping is needed,
+and is pulled with the credentials of a declared registry of the same host, anonymously otherwise. A registry with an
+explicit port has to be declared, as `:` can not be part of a coordinate.
+
+The reasoning behind the separator is documented in
+[docs/decisions/registry-in-coordinates.md](docs/decisions/registry-in-coordinates.md).
+
 ### Reproducible Builds
 
 The artifacts produced by this plugin are fully reproducible.

--- a/docs/decisions/registry-in-coordinates.md
+++ b/docs/decisions/registry-in-coordinates.md
@@ -1,0 +1,149 @@
+# Registry in Coordinates
+
+An OCI image is addressed by a registry and an image reference, while a Gradle dependency is addressed by coordinates
+and resolved from the repositories of the consuming build.
+This plugin maps the registry to a Gradle repository, which is a good fit as long as a build declares the images it
+consumes itself.
+
+It stops fitting as soon as an image is consumed that was built by another build.
+Parent images are transitive dependencies, and repositories are not part of a published component, so the consuming
+build resolves the parent images of an image against its own repositories.
+The registry of a parent image therefore has to be declared in every consuming build, although only the build that
+defines the image knows the registry.
+The consuming build has no way of learning it, because the coordinates it receives contain group, name and version, but
+not the registry.
+
+Carrying the registry in the coordinates removes that gap: a coordinate is then self contained, one repository can serve
+all registries, and a consuming build declares nothing.
+
+The registry is part of the group and not of the name, because the group already represents the namespace of the image
+and a repository can filter on it.
+
+## Constraints
+
+The constraints of [using the digest as version](digest-as-version.md) apply to the group as well:
+
+1. Allowed characters in file system paths:
+
+   The group is part of file and directory names and so must avoid some characters.
+
+   The following characters should be avoided: `NUL, \, /, :, *, ?, ", <, >, |`
+
+2. Allowed characters in registry hosts:
+
+   The separator must be distinguishable from the host.
+
+   Host regex: `[a-zA-Z0-9][a-zA-Z0-9.-]*` optionally followed by `":" port`
+
+3. Allowed characters in image namespaces:
+
+   The separator must be distinguishable from the namespace.
+
+   Path component regex: `[a-z0-9]+([._-][a-z0-9]+)*`, path components are separated by `/`, which this plugin maps to
+   `.` in the group
+
+4. Allowed characters in Gradle's dependency short notation:
+
+   It must be convenient to specify a registry qualified image dependency the same as any other dependency.
+
+   Dependency short notation scheme: `<group>:<name>:<version>[!!]:<classifier>@<extension>`
+
+5. Allowed characters in URLs:
+
+   The group is part of URLs and so must avoid some characters.
+
+   Although more characters can be used (unescaped) in URLs, best is to restrict to: `A-Za-z0-9`, `$-_.+!*'()`
+
+6. The separator should be easy to type.
+
+## Considered Separators
+
+- `\`, `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|`
+
+  CONS:
+  - should be avoided in file system paths, violates constraint 1
+
+- `.`, `-`, `_`
+
+  CONS:
+  - may be used inside a host, violates constraint 2
+  - may be used inside a namespace, violates constraint 3
+
+- `..`
+
+  CONS:
+  - can not be used inside a host or namespace, but reads as a typo
+
+- `@`
+
+  CONS:
+  - does not work in dependency short notation, the rest would be interpreted as extension, violates constraint 4
+
+- `#`, `%`
+
+  CONS:
+  - does not work unescaped in urls, violates constraint 5
+
+- `$`
+
+  CONS:
+  - may be used for string substitution, violates constraint 4
+
+- `(`, `[`, `{` (and closing alternatives)
+
+  CONS:
+  - not good as separator characters, expected in pairs
+
+- `,`, `;`
+
+  CONS:
+  - confusing as separator characters inside a token, expected to separate multiple tokens
+
+- `^`, `§`, `&`, `` ` ``
+
+  CONS:
+  - hard to type or semantically misleading, violates constraint 6
+
+- `'`, `~`
+
+  PROS:
+  - do not violate any constraint
+
+  CONS:
+  - not in the list of characters best to use in URLs
+
+- `+`
+
+  PROS:
+  - does not violate any constraint
+
+  CONS:
+  - reads as a concatenation of two parts rather than a separation
+
+- `!`
+
+  PROS:
+  - does not violate any constraint
+  - already used to represent the boundary that OCI spells differently, the `:` of a digest
+  - does not conflict with forced versions in dependency short notation (`!!`), which apply to the version
+
+## Decision
+
+`!` separates the registry host from the namespace in the group of a registry qualified coordinate.
+
+Example dependency short notation:
+`public.ecr.aws!hivemq.base-images:eclipse-temurin:sha256!5e349bf28c22a00d7ca2dea836586725698ee7252a178ea94c40ba45a59ec4a0`
+
+A group without `!` keeps its current meaning, an image of Docker Hub whose first group segment is dropped as a top
+level domain.
+
+## Consequences
+
+- A registry qualified coordinate is served by a single repository that derives the registry from the group, so no
+  registry has to be declared for it.
+- The namespace of a registry qualified group is not truncated, so no image mapping is needed for a namespace with more
+  than one path component.
+- A registry that requires credentials still has to be declared. A registry qualified coordinate uses the credentials of
+  a declared registry with the same host, and is pulled anonymously otherwise.
+- A registry host with an explicit port can not be expressed, because `:` can not be used in a group. Such a registry
+  has to be declared.

--- a/src/functionalTest/kotlin/io/github/sgtsilvio/gradle/oci/RegistryQualifiedCoordinatesTest.kt
+++ b/src/functionalTest/kotlin/io/github/sgtsilvio/gradle/oci/RegistryQualifiedCoordinatesTest.kt
@@ -1,0 +1,70 @@
+package io.github.sgtsilvio.gradle.oci
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+internal class RegistryQualifiedCoordinatesTest {
+
+    private fun setup(projectDir: File, imageDependency: String, registriesConfiguration: String) {
+        projectDir.resolve("settings.gradle.kts").writeText("""rootProject.name = "test"""")
+        projectDir.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("io.github.sgtsilvio.gradle.oci")
+            }
+            oci {
+                registries {
+                    $registriesConfiguration
+                }
+            }
+            tasks.register("registryData", oci.registryDataTaskClass) {
+                from(oci.imageDependencies.create("registryData") {
+                    runtime("$imageDependency")
+                })
+                registryDataDirectory = layout.buildDirectory.dir("registryData")
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun registryQualifiedCoordinatesResolveWithoutDeclaringTheirRegistry(@TempDir projectDir: File) {
+        setup(
+            projectDir,
+            "registry-1.docker.io!library:eclipse-temurin:20.0.1_9-jre-jammy",
+            """
+            dockerHub {
+                optionalCredentials()
+            }
+            """.trimIndent(),
+        )
+
+        val result =
+            GradleRunner.create().withProjectDir(projectDir).withPluginClasspath().withArguments("registryData").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":registryData")?.outcome)
+        assertTrue(projectDir.resolve("build/registryData/repositories/library/eclipse-temurin").isDirectory)
+    }
+
+    @Test
+    fun registryQualifiedCoordinatesNeedARegistryOrTheSettingsPlugin(@TempDir projectDir: File) {
+        setup(projectDir, "registry-1.docker.io!library:eclipse-temurin:20.0.1_9-jre-jammy", "")
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("registryData")
+            .buildAndFail()
+
+        assertTrue(
+            result.output.contains(
+                "Could not resolve registry-1.docker.io!library:eclipse-temurin:20.0.1_9-jre-jammy"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/image/PushOciImagesTask.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/image/PushOciImagesTask.kt
@@ -81,7 +81,7 @@ abstract class PushOciImagesTask @Inject constructor(private val workerExecutor:
     )
     protected fun setRegistryName(registryName: String) = registry.from(
         project.extensions.getByType(OciExtension::class).registries.list.findByName(registryName)
-            ?: project.settingsRegistriesService?.registries?.findByName(registryName)
+            ?: project.settingsRegistriesService?.registries?.list?.findByName(registryName)
             ?: throw IllegalArgumentException("Registry with name '$registryName' not found.")
     )
 

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/dsl/OciRegistriesImpl.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/dsl/OciRegistriesImpl.kt
@@ -10,6 +10,8 @@ import io.github.sgtsilvio.gradle.oci.internal.gradle.passwordCredentials
 import io.github.sgtsilvio.gradle.oci.internal.reactor.netty.OciLoopResources
 import io.github.sgtsilvio.gradle.oci.internal.reactor.netty.OciRegistryHttpClient
 import io.github.sgtsilvio.gradle.oci.internal.registry.*
+import io.github.sgtsilvio.gradle.oci.internal.registry.OCI_QUALIFIED_REGISTRY_SEGMENT
+import io.github.sgtsilvio.gradle.oci.internal.registry.REGISTRY_SEPARATOR
 import io.github.sgtsilvio.gradle.oci.mapping.OciImageMappingData
 import io.github.sgtsilvio.gradle.oci.mapping.OciImageMappingImpl
 import io.netty.buffer.UnpooledByteBufAllocator
@@ -21,6 +23,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.InclusiveRepositoryContentDescriptor
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor
 import org.gradle.api.credentials.HttpHeaderCredentials
 import org.gradle.api.credentials.PasswordCredentials
@@ -47,6 +50,8 @@ import javax.inject.Inject
 
 internal val OCI_IMAGE_DISTRIBUTION_TYPES = arrayOf(OCI_IMAGE_DISTRIBUTION_TYPE, OCI_IMAGE_INDEX_DISTRIBUTION_TYPE)
 
+private const val QUALIFIED_REPOSITORY_NAME = "qualifiedOciRegistry"
+
 /**
  * @author Silvio Giebl
  */
@@ -56,6 +61,8 @@ internal abstract class OciRegistriesImpl @Inject constructor(
     private val objectFactory: ObjectFactory,
 ) : OciRegistries {
     final override val list = objectFactory.namedDomainObjectList(OciRegistry::class)
+    private var qualifiedRepositoryOrNull: IvyArtifactRepository? = null
+    internal val qualifiedRepository: IvyArtifactRepository? get() = qualifiedRepositoryOrNull
     final override val repositoryPort: Property<Int> = objectFactory.property<Int>().convention(5123)
 
     final override fun registry(name: String, configuration: Action<in OciRegistry>): OciRegistry {
@@ -88,7 +95,39 @@ internal abstract class OciRegistriesImpl @Inject constructor(
             registry.init()
             list += registry
         }
+        registerQualifiedRepository()
         return registry
+    }
+
+    /**
+     * Registers the repository that serves registry qualified coordinates, a coordinate whose group contains the
+     * registry host, for example `ghcr.io!shopify:toxiproxy:2.12.0`. Such a coordinate does not need a declared
+     * registry, which is what allows an image to be consumed without knowing where its parent images are hosted.
+     *
+     * The repository is registered together with the first declared registry instead of unconditionally, so that a
+     * build that declares no repositories at all keeps declaring none.
+     */
+    internal fun registerQualifiedRepository(): IvyArtifactRepository {
+        var repository = qualifiedRepositoryOrNull
+        if (repository == null) {
+            repository = repositoryHandler.ivy {
+                name = QUALIFIED_REPOSITORY_NAME
+                setUrl(repositoryPort.map { port ->
+                    URI("http://localhost:$port/$OCI_REPOSITORY_VERSION/$OCI_QUALIFIED_REGISTRY_SEGMENT")
+                })
+                isAllowInsecureProtocol = true
+                layout("gradle")
+                metadataSources {
+                    gradleMetadata()
+                }
+                content {
+                    onlyForAttribute(DISTRIBUTION_TYPE_ATTRIBUTE, *OCI_IMAGE_DISTRIBUTION_TYPES)
+                    includeGroupByRegex(".*$REGISTRY_SEPARATOR.*")
+                }
+            }
+            qualifiedRepositoryOrNull = repository
+        }
+        return repository
     }
 
     final override fun OciRegistry.exclusiveContent(configuration: Action<in InclusiveRepositoryContentDescriptor>) {
@@ -124,6 +163,8 @@ internal abstract class OciRegistryImpl @Inject constructor(
         }
         content {
             onlyForAttribute(DISTRIBUTION_TYPE_ATTRIBUTE, *OCI_IMAGE_DISTRIBUTION_TYPES)
+            // a registry qualified coordinate names its registry, so it is served by the qualified repository
+            excludeGroupByRegex(".*$REGISTRY_SEPARATOR.*")
         }
     }
 
@@ -143,48 +184,42 @@ private const val PORT_HTTP_HEADER_NAME = "port"
 internal fun OciRegistriesService(
     buildServiceRegistry: BuildServiceRegistry,
     name: String,
-    registries: NamedDomainObjectList<OciRegistry>,
-    repositoryPort: Provider<Int>,
+    registries: OciRegistriesImpl,
     imageMapping: OciImageMappingImpl,
 ): OciRegistriesService {
     val registriesService = buildServiceRegistry.registerIfAbsent(name, OciRegistriesService::class) {}.get()
-    registriesService.init(registries, repositoryPort, imageMapping)
+    registriesService.init(registries, imageMapping)
     return registriesService
 }
 
 internal abstract class OciRegistriesService : BuildService<BuildServiceParameters.None>, AutoCloseable {
     private var state: State? = null
 
-    sealed class State(val registries: NamedDomainObjectList<OciRegistry>) {
+    sealed class State(val registries: OciRegistriesImpl) {
 
         class Initialized(
-            registries: NamedDomainObjectList<OciRegistry>,
-            val repositoryPort: Provider<Int>,
+            registries: OciRegistriesImpl,
             val imageMapping: OciImageMappingImpl,
         ) : State(registries)
 
         class Started(
-            registries: NamedDomainObjectList<OciRegistry>,
+            registries: OciRegistriesImpl,
             val httpServers: List<DisposableServer>,
         ) : State(registries)
 
-        class NoRegistries(registries: NamedDomainObjectList<OciRegistry>) : State(registries)
+        class NoRegistries(registries: OciRegistriesImpl) : State(registries)
 
-        class Closed(registries: NamedDomainObjectList<OciRegistry>) : State(registries)
+        class Closed(registries: OciRegistriesImpl) : State(registries)
     }
 
-    fun init(
-        registries: NamedDomainObjectList<OciRegistry>,
-        repositoryPort: Provider<Int>,
-        imageMapping: OciImageMappingImpl,
-    ) = synchronized(this) {
+    fun init(registries: OciRegistriesImpl, imageMapping: OciImageMappingImpl) = synchronized(this) {
         if (state != null) {
             throw IllegalStateException("OciRegistriesService.init must be called exactly once immediately after creation")
         }
-        state = State.Initialized(registries, repositoryPort, imageMapping)
+        state = State.Initialized(registries, imageMapping)
     }
 
-    val registries: NamedDomainObjectList<OciRegistry>
+    val registries: OciRegistriesImpl
         get() = synchronized(this) {
             state?.registries
                 ?: throw IllegalStateException("OciRegistriesService.registries must be called after init")
@@ -196,21 +231,36 @@ internal abstract class OciRegistriesService : BuildService<BuildServiceParamete
         if (currentState !is State.Initialized) {
             return
         }
-        if (currentState.registries.isEmpty()) {
-            state = State.NoRegistries(currentState.registries)
+        val registries = currentState.registries
+        val qualifiedRepository = registries.qualifiedRepository
+        if (registries.list.isEmpty() && (qualifiedRepository == null)) {
+            state = State.NoRegistries(registries)
         } else {
             val loopResources = OciLoopResources.acquire()
             val httpClient = OciRegistryHttpClient.acquire()
             val httpServers = mutableListOf<DisposableServer>()
-            state = State.Started(currentState.registries, httpServers)
-            val redirectServer = startRedirectServer(currentState.repositoryPort.get(), loopResources)
+            state = State.Started(registries, httpServers)
+            val redirectServer = startRedirectServer(registries.repositoryPort.get(), loopResources)
             if (redirectServer != null) {
                 httpServers += redirectServer
             }
             val imageMetadataRegistry = OciImageMetadataRegistry(OciRegistryApi(httpClient))
             val imageMappingData = currentState.imageMapping.getData()
-            for (registry in currentState.registries) {
+            for (registry in registries.list) {
                 httpServers += startRegistryServer(registry, loopResources, imageMetadataRegistry, imageMappingData)
+            }
+            if (qualifiedRepository != null) {
+                val credentialsByRegistryHost = registries.list.mapNotNull { registry ->
+                    val credentials = registry.credentials.orNull ?: return@mapNotNull null
+                    registry.finalUrl.get().host to Credentials(credentials.username!!, credentials.password!!)
+                }.toMap()
+                httpServers += startQualifiedRegistryServer(
+                    qualifiedRepository,
+                    loopResources,
+                    imageMetadataRegistry,
+                    imageMappingData,
+                    credentialsByRegistryHost,
+                )
             }
         }
     }
@@ -243,6 +293,32 @@ internal abstract class OciRegistriesService : BuildService<BuildServiceParamete
             value = httpServer.port().toString()
         }
         registry.repository.authentication {
+            create<HttpHeaderAuthentication>("header")
+        }
+        return httpServer
+    }
+
+    /**
+     * Serves the coordinates that contain the registry themselves, so one server is enough for all of their registries.
+     * Such an image is pulled with the credentials of a declared registry of the same host, anonymously otherwise.
+     */
+    private fun startQualifiedRegistryServer(
+        repository: IvyArtifactRepository,
+        loopResources: LoopResources,
+        imageMetadataRegistry: OciImageMetadataRegistry,
+        imageMappingData: OciImageMappingData,
+        credentialsByRegistryHost: Map<String, Credentials>,
+    ): DisposableServer {
+        val httpServer = startHttpServer(
+            0,
+            loopResources,
+            OciRepositoryHandler(imageMetadataRegistry, imageMappingData, null, true, credentialsByRegistryHost),
+        )
+        repository.credentials(HttpHeaderCredentials::class) {
+            name = PORT_HTTP_HEADER_NAME
+            value = httpServer.port().toString()
+        }
+        repository.authentication {
             create<HttpHeaderAuthentication>("header")
         }
         return httpServer
@@ -283,25 +359,24 @@ internal abstract class OciRegistriesService : BuildService<BuildServiceParamete
 
 internal fun setupSettingsOciRegistries(
     buildServiceRegistry: BuildServiceRegistry,
-    registries: OciRegistries,
+    registries: OciRegistriesImpl,
     imageMapping: OciImageMappingImpl,
 ) {
-    OciRegistriesService(
-        buildServiceRegistry,
-        SERVICE_BASE_NAME,
-        registries.list,
-        registries.repositoryPort,
-        imageMapping,
-    )
+    // a repository of the settings is shared by all projects and never conflicts with RepositoriesMode
+    registries.registerQualifiedRepository()
+    OciRegistriesService(buildServiceRegistry, SERVICE_BASE_NAME, registries, imageMapping)
 }
 
-internal fun setupProjectOciRegistries(project: Project, registries: OciRegistries, imageMapping: OciImageMappingImpl) {
+internal fun setupProjectOciRegistries(
+    project: Project,
+    registries: OciRegistriesImpl,
+    imageMapping: OciImageMappingImpl,
+) {
     val settingsRegistriesService = project.settingsRegistriesService
     val registriesService = OciRegistriesService(
         project.gradle.sharedServices,
         "$SERVICE_BASE_NAME-${project.path}",
-        registries.list,
-        registries.repositoryPort,
+        registries,
         imageMapping,
     )
     project.configurations.configureEach {

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRepositoryHandler.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRepositoryHandler.kt
@@ -49,12 +49,32 @@ import java.util.function.BiFunction
 internal const val OCI_REPOSITORY_VERSION = "v0.17"
 
 /**
+ * Path segment of the repository that serves registry qualified coordinates, in place of the registry url of a
+ * repository that is bound to a single registry.
+ */
+internal const val OCI_QUALIFIED_REGISTRY_SEGMENT = "qualified"
+
+/**
+ * Separates the registry host from the image namespace in a registry qualified coordinate group, for example
+ * `ghcr.io!shopify:toxiproxy:2.12.0`. Neither a registry host nor an image namespace can contain this character, so the
+ * group can always be split into its two parts.
+ */
+internal const val REGISTRY_SEPARATOR = '!'
+
+/**
  * @author Silvio Giebl
  */
 internal class OciRepositoryHandler(
     private val imageMetadataRegistry: OciImageMetadataRegistry,
     private val imageMappingData: OciImageMappingData,
     private val credentials: Credentials?,
+    /**
+     * Takes the registry from the coordinate group instead of from the request path, see
+     * [OCI_QUALIFIED_REGISTRY_SEGMENT]. The credentials are then looked up by registry host, so that a registry
+     * qualified coordinate of a declared registry is pulled with the credentials of that registry.
+     */
+    private val registryFromGroup: Boolean = false,
+    private val credentialsByRegistryHost: Map<String, Credentials> = emptyMap(),
 ) : BiFunction<HttpServerRequest, HttpServerResponse, Publisher<Void>> {
 
     private val imageMetadataCache: AsyncCache<ImageMetadataCacheKey, OciMultiPlatformImageMetadata> =
@@ -90,12 +110,22 @@ internal class OciRepositoryHandler(
             response.sendNotFound()
         }
         val registryUrl = try {
-            URI(segments[0].unescapePathSegment())
+            if (registryFromGroup) {
+                val group = segments[1]
+                val registryEndIndex = group.indexOf(REGISTRY_SEPARATOR)
+                if (registryEndIndex < 1) {
+                    return response.sendBadRequest()
+                }
+                URI("https://" + group.substring(0, registryEndIndex))
+            } else {
+                URI(segments[0].unescapePathSegment())
+            }
         } catch (e: IllegalArgumentException) {
             return response.sendBadRequest()
         } catch (e: URISyntaxException) {
             return response.sendBadRequest()
         }
+        val credentials = if (registryFromGroup) credentialsByRegistryHost[registryUrl.host] else credentials
         if ((segments.size == 5) && segments[4].endsWith(".module")) {
             val componentId = VersionedCoordinates(segments[1], segments[2], segments[3])
             val mappedComponent = imageMappingData.map(componentId)
@@ -103,8 +133,8 @@ internal class OciRepositoryHandler(
         }
         val last = segments.last()
         return when {
-            last.endsWith(".json") -> getOrHeadMetadata(registryUrl, segments, isGet, response)
-            last.endsWith("oci-layer") -> getOrHeadLayer(registryUrl, segments, isGet, response)
+            last.endsWith(".json") -> getOrHeadMetadata(registryUrl, credentials, segments, isGet, response)
+            last.endsWith("oci-layer") -> getOrHeadLayer(registryUrl, credentials, segments, isGet, response)
             else -> response.sendNotFound()
         }
     }
@@ -215,6 +245,7 @@ internal class OciRepositoryHandler(
 
     private fun getOrHeadMetadata(
         registryUrl: URI,
+        credentials: Credentials?,
         segments: List<String>,
         isGet: Boolean,
         response: HttpServerResponse,
@@ -257,6 +288,7 @@ internal class OciRepositoryHandler(
 
     private fun getOrHeadLayer(
         registryUrl: URI,
+        credentials: Credentials?,
         segments: List<String>,
         isGet: Boolean,
         response: HttpServerResponse,

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/mapping/OciImageMapper.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/mapping/OciImageMapper.kt
@@ -1,5 +1,6 @@
 package io.github.sgtsilvio.gradle.oci.mapping
 
+import io.github.sgtsilvio.gradle.oci.internal.registry.REGISTRY_SEPARATOR
 import io.github.sgtsilvio.gradle.oci.metadata.OciImageReference
 import java.util.*
 
@@ -77,7 +78,15 @@ private fun defaultMappedComponent(componentId: VersionedCoordinates) = OciImage
     ),
 )
 
-internal fun defaultMappedImageNamespace(group: String) = when (val tldEndIndex = group.indexOf('.')) {
-    -1 -> if (group.isEmpty()) "" else "$group/"
-    else -> group.substring(tldEndIndex + 1).replace('.', '/') + '/'
+internal fun defaultMappedImageNamespace(group: String): String {
+    val registryEndIndex = group.indexOf(REGISTRY_SEPARATOR)
+    if (registryEndIndex != -1) {
+        // a registry qualified group contains the namespace as is, there is no tld to skip
+        val namespace = group.substring(registryEndIndex + 1)
+        return if (namespace.isEmpty()) "" else namespace.replace('.', '/') + '/'
+    }
+    return when (val tldEndIndex = group.indexOf('.')) {
+        -1 -> if (group.isEmpty()) "" else "$group/"
+        else -> group.substring(tldEndIndex + 1).replace('.', '/') + '/'
+    }
 }

--- a/src/test/kotlin/io/github/sgtsilvio/gradle/oci/mapping/OciImageMapperTest.kt
+++ b/src/test/kotlin/io/github/sgtsilvio/gradle/oci/mapping/OciImageMapperTest.kt
@@ -1,0 +1,22 @@
+package io.github.sgtsilvio.gradle.oci.mapping
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class OciImageMapperTest {
+
+    @Test
+    fun group_isMappedToImageNamespace() {
+        assertEquals("", defaultMappedImageNamespace(""))
+        assertEquals("library/", defaultMappedImageNamespace("library"))
+        assertEquals("google/cloudsdktool/", defaultMappedImageNamespace("com.google.cloudsdktool"))
+    }
+
+    @Test
+    fun registryQualifiedGroup_isMappedToImageNamespaceAsIs() {
+        assertEquals("library/", defaultMappedImageNamespace("registry-1.docker.io!library"))
+        assertEquals("base-images/", defaultMappedImageNamespace("public.ecr.aws!base-images"))
+        assertEquals("hivemq/base-images/", defaultMappedImageNamespace("public.ecr.aws!hivemq.base-images"))
+        assertEquals("", defaultMappedImageNamespace("registry-1.docker.io!"))
+    }
+}


### PR DESCRIPTION
## Summary

Parent images are transitive dependencies, and repositories are not part of a published component, so a build resolves the parent images of an image it consumes against its own repositories. The registry of a parent image therefore has to be declared in every consuming build, although only the build that defines the image knows it: the coordinates carry group, name and version, but not the registry.

This adds registry qualified coordinates, whose group names the registry, separated from the image namespace by `!`:

```kotlin
runtime("public.ecr.aws!hivemq.base-images:eclipse-temurin:sha256!5e349bf2...")
```

- A single repository serves all such coordinates and derives the registry from the group, so no registry has to be declared for them.
- The namespace of a registry qualified group is not truncated as a top level domain, so no `imageMapping` is needed for a namespace with more than one path component.
- A registry qualified coordinate is pulled with the credentials of a declared registry of the same host, and anonymously otherwise, so private registries keep working through a normal registry declaration.
- A group without `!` keeps its current meaning, and the repositories of declared registries exclude qualified groups, so nothing changes for existing builds.
- The separator is chosen in `docs/decisions/registry-in-coordinates.md`, following the constraints of `docs/decisions/digest-as-version.md`. `!` is the only single character that satisfies all of them and is already used for the other boundary that OCI spells differently, the `:` of a digest.

## Why

Without this, an image cannot be consumed without knowing where its parent images are hosted. In a composite of around 15 builds, moving one base image to another registry means declaring that registry in every build that consumes any image built on it, and again on every later change of registry or namespace.

## Notes

- The qualified repository is registered together with the first declared registry, or by the settings plugin, so a build that declares nothing keeps declaring nothing and `RepositoriesMode.FAIL_ON_PROJECT_REPOS` is unaffected.
- A registry host with an explicit port cannot be expressed, since `:` cannot be part of a coordinate. Such a registry is declared as before.
- Verified against ECR Public and Docker Hub with qualified coordinates, including a namespace with two path components. The functional tests that need Docker Hub credentials were not run locally.
