### PR TITLE
Authenticate via the challenge instead of sending basic auth proactively

### DIFF
--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
@@ -37,6 +37,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 
 /*
 https://github.com/opencontainers/distribution-spec/blob/main/spec.md
@@ -73,6 +74,13 @@ internal class OciRegistryApi(httpClient: HttpClient) {
     private val httpClient = httpClient.followRedirect(true)
     private val tokenCache: AsyncCache<TokenCacheKey, OciRegistryToken> =
         Caffeine.newBuilder().expireAfter(TokenCacheExpiry).buildAsync()
+
+    // Registries that answered with a "Basic" (not "Bearer") authentication challenge. Credentials are sent to these
+    // registries directly; for "Bearer" registries they are sent to the token endpoint instead. Remembering which
+    // registries use basic auth lets us send the credentials proactively after the first challenge, avoiding an extra
+    // round trip per request without sending basic auth to registries that reject it (the AWS ECR Public registry, for
+    // example, responds with 400 to basic auth on the registry endpoint).
+    private val basicAuthRegistryUrls: MutableSet<URI> = ConcurrentHashMap.newKeySet()
 
     private data class TokenCacheKey(
         val registryUrl: URI,
@@ -548,6 +556,14 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String>? {
+        val authHeader = responseHeaders[HttpHeaderNames.WWW_AUTHENTICATE] ?: return null
+        // A "Basic" challenge is answered by sending the credentials to the registry directly. Remember the registry so
+        // the credentials are sent proactively next time (getAuthorization) instead of paying for another challenge.
+        if (authHeader.startsWith("Basic ")) {
+            if (credentials == null) return null
+            basicAuthRegistryUrls.add(registryUrl)
+            return Mono.just(credentials.encodeBasicAuthorization())
+        }
         val bearerParams = decodeBearerParams(responseHeaders) ?: return null // TODO return parsing error
         val realm = bearerParams["realm"] ?: throw IllegalArgumentException("bearer authorization header is missing 'realm'")
         val service = bearerParams["service"] ?: throw IllegalArgumentException("bearer authorization header is missing 'service'")
@@ -597,9 +613,17 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String> {
-        return tokenCache.getIfPresentMono(TokenCacheKey(registryUrl, scopes, credentials?.hashed()))
+        val cachedBearerAuthorization = tokenCache.getIfPresentMono(TokenCacheKey(registryUrl, scopes, credentials?.hashed()))
             .map { encodeBearerAuthorization(it.token) }
-            .run { if (credentials == null) this else defaultIfEmpty(credentials.encodeBasicAuthorization()) }
+        // Basic auth is sent proactively only to registries already known to use it. A bearer registry gets no
+        // credentials on the first request: it answers with a "Bearer" challenge, which tryAuthorize turns into a token
+        // request against the token endpoint. This follows the Docker registry v2 token authentication flow and avoids
+        // sending basic auth to registries that reject it on the registry endpoint.
+        return if ((credentials != null) && (registryUrl in basicAuthRegistryUrls)) {
+            cachedBearerAuthorization.defaultIfEmpty(credentials.encodeBasicAuthorization())
+        } else {
+            cachedBearerAuthorization
+        }
     }
 
     private fun Credentials.encodeBasicAuthorization() =


### PR DESCRIPTION
## Problem

With credentials configured, an authenticated pull from the **AWS ECR Public** registry (`public.ecr.aws`) fails:

```
GET /v2/<name>/manifests/<ref>   Authorization: Basic …   → 400
{"errors":[{"code":"DENIED","message":"Your Authorization Token is invalid."}]}
```

`getAuthorization` sends a basic `Authorization` header **proactively** on the first request. ECR Public's registry endpoint rejects basic auth with **400** (not 401), and `send()` only re-authorizes on 401 (`statusCode != 401 -> throw`), so the build fails before the token endpoint — where the credentials actually belong — is ever reached.

Most bearer registries happen to tolerate the proactive basic header (they answer **401**, and the request is then re-authorized via the token endpoint), which is why this only surfaces on ECR Public. But sending basic auth straight to the registry isn't the token-auth flow.

## Change

Follow the [Docker registry v2 token authentication spec](https://distribution.github.io/distribution/spec/auth/token/): contact the registry first without credentials, read the `WWW-Authenticate` challenge, and respond to it.

- **Bearer** challenge → request a token from the token endpoint with basic auth (unchanged).
- **Basic** challenge → send the credentials to the registry directly, and remember the registry so subsequent requests send them proactively (keeping the extra round trip to once per registry, not once per request).

`getAuthorization` no longer sends basic auth to a not-yet-classified registry, so ECR Public now gets an unauthenticated request → `401 Bearer` → token endpoint with basic → authenticated bearer.

## Compatibility

- **Anonymous pulls**: unchanged — `credentials == null` still yields cached-bearer-or-nothing, and a bearer challenge takes the same path as before.
- **Bearer registries** (Docker Hub, GHCR, ECR Public): first request is now unauthenticated instead of carrying an ignored basic header; the token flow is otherwise identical.
- **Basic-auth registries** (e.g. private ECR, htpasswd): one extra 401 on the first request per registry, then proactive basic as before.

## Verification

- `./gradlew test` passes.
- Traced against the real ECR Public registry: the flow is now `Authorization: none → 401 (Bearer scope="aws")` followed by a token-endpoint request and a bearer-authorized retry, where it previously sent `Authorization: Basic → 400`.

Note: I confirmed the corrected **flow** end-to-end (no-auth → 401 → token endpoint → bearer retry); confirming a successful authenticated pull requires a valid AWS credential (`aws ecr-public get-login-password`), which I couldn't exercise in this environment. Opening as a draft for that reason and for your input on the approach — happy to add a mock-registry test for the challenge handling if you'd like one.