### PR TITLE
Authenticate via the challenge instead of sending basic auth proactively

### DIFF
--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
@@ -548,6 +548,11 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String>? {
+        val authHeader = responseHeaders[HttpHeaderNames.WWW_AUTHENTICATE] ?: return null
+        // A "Basic" challenge is answered by sending the credentials to the registry directly.
+        if (authHeader.startsWith("Basic ")) {
+            return if (credentials == null) null else Mono.just(credentials.encodeBasicAuthorization())
+        }
         val bearerParams = decodeBearerParams(responseHeaders) ?: return null // TODO return parsing error
         val realm = bearerParams["realm"] ?: throw IllegalArgumentException("bearer authorization header is missing 'realm'")
         val service = bearerParams["service"] ?: throw IllegalArgumentException("bearer authorization header is missing 'service'")
@@ -597,9 +602,13 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String> {
+        // Do not send credentials proactively. A registry that uses the token flow answers an unauthenticated request
+        // with a "Bearer" challenge, which tryAuthorize turns into a request to the token endpoint; a registry that uses
+        // basic auth answers with a "Basic" challenge, which tryAuthorize answers by sending the credentials directly.
+        // This follows the Docker registry v2 token authentication flow and avoids sending basic auth to registries that
+        // reject it on the registry endpoint (the AWS ECR Public registry, for example, responds with 400).
         return tokenCache.getIfPresentMono(TokenCacheKey(registryUrl, scopes, credentials?.hashed()))
             .map { encodeBearerAuthorization(it.token) }
-            .run { if (credentials == null) this else defaultIfEmpty(credentials.encodeBasicAuthorization()) }
     }
 
     private fun Credentials.encodeBasicAuthorization() =

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
@@ -553,7 +553,7 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         if (authHeader.startsWith("Basic ")) {
             return if (credentials == null) null else Mono.just(credentials.encodeBasicAuthorization())
         }
-        val bearerParams = decodeBearerParams(responseHeaders) ?: return null // TODO return parsing error
+        val bearerParams = decodeBearerParams(authHeader) ?: return null // TODO return parsing error
         val realm = bearerParams["realm"] ?: throw IllegalArgumentException("bearer authorization header is missing 'realm'")
         val service = bearerParams["service"] ?: throw IllegalArgumentException("bearer authorization header is missing 'service'")
         val scope = bearerParams["scope"] ?: throw IllegalArgumentException("bearer authorization header is missing 'scope'")
@@ -616,8 +616,7 @@ internal class OciRegistryApi(httpClient: HttpClient) {
 
     private fun encodeBearerAuthorization(token: String) = "Bearer $token" // TODO move out
 
-    private fun decodeBearerParams(headers: HttpHeaders): Map<String, String>? { // TODO move out
-        val authHeader = headers[HttpHeaderNames.WWW_AUTHENTICATE] ?: return null
+    private fun decodeBearerParams(authHeader: String): Map<String, String>? { // TODO move out
         if (!authHeader.startsWith("Bearer ")) return null
         val authParamString = authHeader.substring("Bearer ".length)
         val map = HashMap<String, String>()


### PR DESCRIPTION
## Problem

With credentials configured, an authenticated pull from the **AWS ECR Public** registry (`public.ecr.aws`) fails:

```
GET /v2/<name>/manifests/<ref>   Authorization: Basic …   → 400
{"errors":[{"code":"DENIED","message":"Your Authorization Token is invalid."}]}
```

`getAuthorization` sends a basic `Authorization` header **proactively** on the first request. ECR Public's registry endpoint rejects basic auth with **400** (not 401), and `send()` only re-authorizes on 401 (`statusCode != 401 -> throw`), so the build fails before the token endpoint — where the credentials belong — is ever reached. Most bearer registries tolerate the proactive basic header (they answer **401** and the request is re-authorized), which is why this only surfaces on ECR Public.

## Change

Follow the [Docker registry v2 token authentication spec](https://distribution.github.io/distribution/spec/auth/token/): contact the registry first without credentials, read the `WWW-Authenticate` challenge, and respond to it.

- **Bearer** challenge → request a token from the token endpoint with basic auth (unchanged).
- **Basic** challenge → send the credentials to the registry directly.

`getAuthorization` no longer sends basic auth proactively, so ECR Public gets an unauthenticated request → `401 Bearer` → token endpoint → authenticated bearer.

## Verified against the two ECR flavours

The AWS docs confirm the scheme difference this relies on — [private ECR uses `Authorization: Basic`](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html), [ECR Public uses `Authorization: Bearer`](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registry-auth.html) — and both challenges are reproducible live (`public.ecr.aws` → `401 Bearer scope="aws"`; a private ECR registry → `401 Basic`).

## Compatibility

- **Anonymous pulls**: unchanged (`credentials == null` yields cached-bearer-or-nothing; a bearer challenge takes the same path as before).
- **Bearer registries** (Docker Hub, GHCR, ECR Public): first request is unauthenticated instead of carrying an ignored basic header; the token flow is otherwise identical.
- **Basic-auth registries** (private ECR, htpasswd): one extra 401 on the first request per request — a follow-up PR removes that by remembering basic-auth registries.

## Verification

- `./gradlew test` passes.
- Traced against the real ECR Public registry: the flow is now `Authorization: none → 401 (Bearer scope="aws")` → token endpoint → bearer-authorized retry, where it previously sent `Authorization: Basic → 400`.

Draft: I confirmed the corrected **flow** end-to-end; confirming a *successful authenticated pull* needs a valid AWS credential (`aws ecr-public get-login-password`), which I couldn't exercise here. Happy to add a mock-registry test for the challenge handling.