### PR TITLE
Send basic auth proactively to registries known to use it

### DIFF
--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
@@ -548,6 +548,11 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String>? {
+        val authHeader = responseHeaders[HttpHeaderNames.WWW_AUTHENTICATE] ?: return null
+        // A "Basic" challenge is answered by sending the credentials to the registry directly.
+        if (authHeader.startsWith("Basic ")) {
+            return if (credentials == null) null else Mono.just(credentials.encodeBasicAuthorization())
+        }
         val bearerParams = decodeBearerParams(responseHeaders) ?: return null // TODO return parsing error
         val realm = bearerParams["realm"] ?: throw IllegalArgumentException("bearer authorization header is missing 'realm'")
         val service = bearerParams["service"] ?: throw IllegalArgumentException("bearer authorization header is missing 'service'")
@@ -597,9 +602,13 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String> {
+        // Do not send credentials proactively. A registry that uses the token flow answers an unauthenticated request
+        // with a "Bearer" challenge, which tryAuthorize turns into a request to the token endpoint; a registry that uses
+        // basic auth answers with a "Basic" challenge, which tryAuthorize answers by sending the credentials directly.
+        // This follows the Docker registry v2 token authentication flow and avoids sending basic auth to registries that
+        // reject it on the registry endpoint (the AWS ECR Public registry, for example, responds with 400).
         return tokenCache.getIfPresentMono(TokenCacheKey(registryUrl, scopes, credentials?.hashed()))
             .map { encodeBearerAuthorization(it.token) }
-            .run { if (credentials == null) this else defaultIfEmpty(credentials.encodeBasicAuthorization()) }
     }
 
     private fun Credentials.encodeBasicAuthorization() =

--- a/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
+++ b/src/main/kotlin/io/github/sgtsilvio/gradle/oci/internal/registry/OciRegistryApi.kt
@@ -37,6 +37,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 
 /*
 https://github.com/opencontainers/distribution-spec/blob/main/spec.md
@@ -73,6 +74,12 @@ internal class OciRegistryApi(httpClient: HttpClient) {
     private val httpClient = httpClient.followRedirect(true)
     private val tokenCache: AsyncCache<TokenCacheKey, OciRegistryToken> =
         Caffeine.newBuilder().expireAfter(TokenCacheExpiry).buildAsync()
+
+    // Registries that answered with a "Basic" (not "Bearer") authentication challenge. Once a registry is known to use
+    // basic auth, the credentials are sent to it proactively, avoiding a challenge round trip on every request. This
+    // keeps the extra round trip introduced by challenge-based authentication to once per registry, not once per
+    // request, for basic-auth registries such as a private AWS ECR registry.
+    private val basicAuthRegistryUrls: MutableSet<URI> = ConcurrentHashMap.newKeySet()
 
     private data class TokenCacheKey(
         val registryUrl: URI,
@@ -549,9 +556,12 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         credentials: Credentials?,
     ): Mono<String>? {
         val authHeader = responseHeaders[HttpHeaderNames.WWW_AUTHENTICATE] ?: return null
-        // A "Basic" challenge is answered by sending the credentials to the registry directly.
+        // A "Basic" challenge is answered by sending the credentials to the registry directly. Remember the registry so
+        // the credentials are sent proactively next time (getAuthorization) instead of paying for another challenge.
         if (authHeader.startsWith("Basic ")) {
-            return if (credentials == null) null else Mono.just(credentials.encodeBasicAuthorization())
+            if (credentials == null) return null
+            basicAuthRegistryUrls.add(registryUrl)
+            return Mono.just(credentials.encodeBasicAuthorization())
         }
         val bearerParams = decodeBearerParams(responseHeaders) ?: return null // TODO return parsing error
         val realm = bearerParams["realm"] ?: throw IllegalArgumentException("bearer authorization header is missing 'realm'")
@@ -602,13 +612,17 @@ internal class OciRegistryApi(httpClient: HttpClient) {
         scopes: Set<OciRegistryResourceScope>,
         credentials: Credentials?,
     ): Mono<String> {
-        // Do not send credentials proactively. A registry that uses the token flow answers an unauthenticated request
-        // with a "Bearer" challenge, which tryAuthorize turns into a request to the token endpoint; a registry that uses
-        // basic auth answers with a "Basic" challenge, which tryAuthorize answers by sending the credentials directly.
-        // This follows the Docker registry v2 token authentication flow and avoids sending basic auth to registries that
-        // reject it on the registry endpoint (the AWS ECR Public registry, for example, responds with 400).
-        return tokenCache.getIfPresentMono(TokenCacheKey(registryUrl, scopes, credentials?.hashed()))
+        val cachedBearerAuthorization = tokenCache.getIfPresentMono(TokenCacheKey(registryUrl, scopes, credentials?.hashed()))
             .map { encodeBearerAuthorization(it.token) }
+        // Basic auth is sent proactively only to registries already known to use it (see basicAuthRegistryUrls). A
+        // registry that uses the token flow gets no credentials on the first request: it answers with a "Bearer"
+        // challenge, which tryAuthorize turns into a token request. This avoids sending basic auth to registries that
+        // reject it on the registry endpoint (the AWS ECR Public registry, for example, responds with 400).
+        return if ((credentials != null) && (registryUrl in basicAuthRegistryUrls)) {
+            cachedBearerAuthorization.defaultIfEmpty(credentials.encodeBasicAuthorization())
+        } else {
+            cachedBearerAuthorization
+        }
     }
 
     private fun Credentials.encodeBasicAuthorization() =


### PR DESCRIPTION
> **Stacked on the previous PR** (`ecr-public-auth-via-challenge`). Its commit appears here too until that one merges — **review the second commit** (`Send basic auth proactively to registries known to use it`). Merge the base PR first.

## Why

The base PR authenticates by responding to the registry's `WWW-Authenticate` challenge. For a **basic-auth registry** that means every request starts unauthenticated and is answered with a `401 Basic` challenge before the credentials are sent — an extra round trip *per request*.

## Change

Remember which registries challenge with **Basic** auth, and send the credentials to them proactively on subsequent requests. The extra round trip is then paid **once per registry** instead of once per request.

Registries that use the token flow (Docker Hub, GHCR, ECR Public) are never added to the set, so they still receive no credentials on the first request and are authenticated via the token endpoint — unchanged.

## Context

A **private** AWS ECR registry [uses basic auth on the registry endpoint](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) (the documented `curl -H "Authorization: Basic \$TOKEN" …`), unlike [ECR Public which uses bearer tokens](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registry-auth.html). This restores single-request pulls for such registries after the base PR.

## Verification

- `./gradlew test` passes.
- The delta over the base PR is a single field plus proactive-send logic; the token-flow path is untouched.